### PR TITLE
Handle paginated downloads when scraping

### DIFF
--- a/cklb_handler.py
+++ b/cklb_handler.py
@@ -177,7 +177,7 @@ def upgrade_cklbs_no_edit_tui(stdscr):
     import curses
     import textwrap
     from tui import browse_and_select_cklb_files
-    from web import fetch_page, parse_table_for_links, download_file, URL
+    from web import collect_all_file_links, download_file
     from create_cklb import convert_xccdf_zip_to_cklb
     updated_dir = os.path.join("user_docs", "cklb_updated")
     os.makedirs(updated_dir, exist_ok=True)
@@ -248,8 +248,7 @@ def upgrade_cklbs_no_edit_tui(stdscr):
                 stdscr.addstr(0, 0, "Fetching available STIGs from website...")
                 stdscr.refresh()
                 try:
-                    html_content = fetch_page(URL)
-                    file_links = parse_table_for_links(html_content)
+                    file_links = collect_all_file_links()
                 except Exception as e:
                     stdscr.addstr(2, 0, f"Error fetching website: {e}. Press any key to return.")
                     stdscr.refresh()
@@ -359,7 +358,7 @@ def upgrade_cklbs_answer_tui(stdscr):
     import curses
     import textwrap
     from tui import browse_and_select_cklb_files
-    from web import fetch_page, parse_table_for_links, download_file, URL
+    from web import collect_all_file_links, download_file
     from create_cklb import convert_xccdf_zip_to_cklb
     updated_dir = os.path.join("user_docs", "cklb_updated")
     os.makedirs(updated_dir, exist_ok=True)
@@ -429,8 +428,7 @@ def upgrade_cklbs_answer_tui(stdscr):
                 stdscr.addstr(0, 0, "Fetching available STIGs from website...")
                 stdscr.refresh()
                 try:
-                    html_content = fetch_page(URL)
-                    file_links = parse_table_for_links(html_content)
+                    file_links = collect_all_file_links()
                 except Exception as e:
                     stdscr.addstr(2, 0, f"Error fetching website: {e}. Press any key to return.")
                     stdscr.refresh()

--- a/tests/fixtures/pagination_empty.html
+++ b/tests/fixtures/pagination_empty.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <section class="results">
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/pagination_no_nav_page1.html
+++ b/tests/fixtures/pagination_no_nav_page1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <section class="results">
+      <div data-link="https://example.com/files/file10.zip">File 10</div>
+      <div data-link="https://example.com/files/file20.zip">File 20</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/pagination_no_nav_page2.html
+++ b/tests/fixtures/pagination_no_nav_page2.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <section class="results">
+      <div data-link="https://example.com/files/file20.zip">Repeat file</div>
+      <div data-link="https://example.com/files/file30.zip">File 30</div>
+    </section>
+  </body>
+</html>

--- a/tests/fixtures/pagination_page1.html
+++ b/tests/fixtures/pagination_page1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <section class="results">
+      <div data-link="https://example.com/files/file1.zip">File 1</div>
+      <div data-link="https://example.com/files/file2.zip">File 2</div>
+    </section>
+    <nav class="usa-pagination" aria-label="Pagination">
+      <a class="usa-pagination__link usa-pagination__next-page" href="/downloads?page=2" rel="next">Next</a>
+    </nav>
+  </body>
+</html>

--- a/tests/fixtures/pagination_page2.html
+++ b/tests/fixtures/pagination_page2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <section class="results">
+      <div data-link="https://example.com/files/file2.zip">Duplicate of page one</div>
+      <div data-link="https://example.com/files/file3.zip">File 3</div>
+    </section>
+    <nav class="usa-pagination" aria-label="Pagination">
+      <a class="usa-pagination__link usa-pagination__next-page" href="/downloads?page=3" rel="next">Next</a>
+    </nav>
+  </body>
+</html>

--- a/tests/fixtures/pagination_page3_empty.html
+++ b/tests/fixtures/pagination_page3_empty.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>No results found.</p>
+  </body>
+</html>

--- a/tests/test_web_pagination.py
+++ b/tests/test_web_pagination.py
@@ -1,0 +1,53 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from web import collect_all_file_links
+
+
+class CollectAllFileLinksTests(unittest.TestCase):
+    def load_fixture(self, name: str) -> str:
+        fixture_path = Path(__file__).parent / "fixtures" / name
+        return fixture_path.read_text(encoding="utf-8")
+
+    def test_collect_all_file_links_follows_rel_next(self):
+        pages = {
+            "https://example.com/downloads?page=1": self.load_fixture("pagination_page1.html"),
+            "https://example.com/downloads?page=2": self.load_fixture("pagination_page2.html"),
+            "https://example.com/downloads?page=3": self.load_fixture("pagination_page3_empty.html"),
+        }
+
+        with patch("web.fetch_page", side_effect=lambda url: pages[url]):
+            results = collect_all_file_links("https://example.com/downloads?page=1")
+
+        self.assertEqual(
+            results,
+            [
+                ("file1.zip", "https://example.com/files/file1.zip"),
+                ("file2.zip", "https://example.com/files/file2.zip"),
+                ("file3.zip", "https://example.com/files/file3.zip"),
+            ],
+        )
+
+    def test_collect_all_file_links_increments_page_query_when_no_nav(self):
+        pages = {
+            "https://example.com/downloads?page=5": self.load_fixture("pagination_no_nav_page1.html"),
+            "https://example.com/downloads?page=6": self.load_fixture("pagination_no_nav_page2.html"),
+            "https://example.com/downloads?page=7": self.load_fixture("pagination_empty.html"),
+        }
+
+        with patch("web.fetch_page", side_effect=lambda url: pages[url]):
+            results = collect_all_file_links("https://example.com/downloads?page=5")
+
+        self.assertEqual(
+            results,
+            [
+                ("file10.zip", "https://example.com/files/file10.zip"),
+                ("file20.zip", "https://example.com/files/file20.zip"),
+                ("file30.zip", "https://example.com/files/file30.zip"),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tui.py
+++ b/tui.py
@@ -38,7 +38,7 @@ from input_validation import (
     get_safe_path
 )
 from log_config import setup_logging, get_operation_logger
-from web import fetch_page, parse_table_for_links, download_file, URL, HEADERS
+from web import collect_all_file_links, download_file
 from cklb_handler import (
     compare_cklb_versions, upgrade_cklb_no_edit,
     upgrade_cklbs_no_edit_tui, upgrade_cklbs_answer_tui
@@ -91,8 +91,7 @@ def download_files(stdscr):
     while True:
         show_progress(stdscr, "Fetching webpage and parsing file links...")
         try:
-            html_content = fetch_page(URL)
-            file_links = parse_table_for_links(html_content)
+            file_links = collect_all_file_links()
         except Exception as e:
             clean_screen(stdscr)
             draw_status_bar(stdscr, f"Error: {e}. Press any key to return.", "error")
@@ -201,8 +200,7 @@ def create_inventory_file_tui(stdscr):
     
     show_progress(stdscr, "Fetching webpage and parsing file links...")
     try:
-        html_content = fetch_page(URL)
-        file_links = parse_table_for_links(html_content)
+        file_links = collect_all_file_links()
     except Exception as e:
         clean_screen(stdscr)
         draw_status_bar(stdscr, f"Error: {e}. Press any key to return.", "error")
@@ -644,7 +642,7 @@ def automatic_cklb_library_update_tui(stdscr):
     """
     import os, json, re, logging
     from datetime import datetime
-    from web import fetch_page, parse_table_for_links, download_file, URL
+    from web import collect_all_file_links, download_file
     from create_cklb import convert_xccdf_zip_to_cklb
     import shutil
     # Ensure log dir exists
@@ -716,8 +714,7 @@ def automatic_cklb_library_update_tui(stdscr):
     stdscr.addstr(0, 0, "Fetching available STIGs from website...")
     stdscr.refresh()
     try:
-        html_content = fetch_page(URL)
-        file_links = parse_table_for_links(html_content)
+        file_links = collect_all_file_links()
     except Exception as e:
         stdscr.addstr(2, 0, f"Error fetching website: {e}. Press any key to return.")
         stdscr.refresh()


### PR DESCRIPTION
## Summary
- add a pagination-aware helper that follows the `nav.usa-pagination` widget (or increments the `page` query) and aggregates unique checklist downloads
- switch TUI and CKLB upgrade flows to use the aggregated download list instead of a single page fetch
- add offline HTML fixtures with unit tests that exercise both the `rel="next"` path and the `?page=` fallback

## Testing
- python -m unittest discover tests

------
https://chatgpt.com/codex/tasks/task_e_68cbb149b1cc8330a10547874102ec7d